### PR TITLE
Basic package management implemented

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires = [
     'colorama',
     'pyserial>=3,<4',
     'six',
+    'gitpython',
 ]
 
 

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -4,10 +4,11 @@ A lightweight package management system for WCosa.
 """
 
 import json
-import git
 import os
 import re
 import sys
+
+import git
 
 from wcosa.utils.output import write, writeln
 
@@ -45,7 +46,7 @@ class GitFetchException(Exception):
                      else ''))
 
     def __str__(self):
-        return 'Could not fetch submodule from %s' + package.url
+        return 'Could not fetch submodule from %s' + self.url
 
 
 class AlreadyInstalledException(Exception):
@@ -104,7 +105,7 @@ def package_list_read(pkgpath):
     try:
         with open(pkgpath + '/pkglist', 'r') as pkglistfile:
             return json.loads(pkglistfile.read())
-    except:
+    except Exception:
         return []
 
 
@@ -145,7 +146,7 @@ def package_repo_open(pkgpath):
     """Try to open package repo; initalize upon failure"""
     try:
         return git.Repo(pkgpath)
-    except:
+    except Exception:
         return package_repo_init(pkgpath)
 
 
@@ -172,7 +173,7 @@ def package_link(path, package):
     link_basedir = '/'.join(link_path.split('/')[:-1])
     try:
         os.mkdir(link_basedir)
-    except:
+    except Exception:
         pass  # Already exists or failed (then next try will fail)
     try:
         os.symlink(install_path, link_path)
@@ -181,7 +182,7 @@ def package_link(path, package):
             current_path = os.readlink(link_path)
             if current_path == install_path:
                 return  # Then we're done
-        except:
+        except Exception:
             pass
         raise (type(e))('Could not link package: ' + str(e))
 
@@ -209,9 +210,9 @@ def _package_install_unsafe(path, package, pkgrepo, pkglist, pkgnames):
             raise AlreadyInstalledException(link_updated=True)
     # If the above did not return, we need to actually install the package
     try:
-        sm = pkgrepo.create_submodule(package.name, package.name,
-                                      url=package.url, branch=package.branch)
-    except:  # Default message is cryptic
+        pkgrepo.create_submodule(package.name, package.name,
+                                 url=package.url, branch=package.branch)
+    except Exception:  # Default message is cryptic
         raise GitFetchException(package)
     package_link(path, package)
     writeln('Installed.')
@@ -226,7 +227,7 @@ def package_install(path, package, batch_mode=False, pkgrepo=None,
     """
     pkgpath = package_dir_path(path)
     if pkgrepo is None:
-        pkgepo = package_repo_open(pkgpath)
+        pkgrepo = package_repo_open(pkgpath)
     if pkglist is None:
         pkglist = package_list_read(pkgpath)
     if pkgnames is None:
@@ -243,7 +244,7 @@ def package_install(path, package, batch_mode=False, pkgrepo=None,
         try:
             sm = pkgrepo.submodule(package.name)
             sm.remove()
-        except:
+        except Exception:
             pass
         pkgrepo.git.clean('-fdX')  # Remove all untracked files
         writeln('Install aborted.')

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -1,5 +1,6 @@
 import git
 import re
+import os, sys
 from wcosa.utils.output import write, writeln
 
 class Package:
@@ -22,8 +23,8 @@ class PackageFormatError(Exception):
         return "Bad package format: " + self.package_string
 
 FULL_URL = r'(?P<url>https?://\S+/(?P<name>\S+))'
-GITHUB = r'(?P<github>\w+/(?P<name>\w+))'
-BRANCH = r'(:(?P<branch>\w+))?'
+GITHUB = r'(?P<github>[\w\-]+/(?P<name>[\w\-]+))'
+BRANCH = r'(:(?P<branch>[\w\-]+))?'
 VERSION = r'@(?P<version>\S+)'
 PATH = r'( as (?P<path>\S+))?'
 VALID_SCHEMAS = [re.compile('^' + FULL_URL + BRANCH + VERSION + PATH + '$'),
@@ -59,3 +60,43 @@ def parse_package_names(package_strings):
         path = groups['path']
         packages.append(Package(name, url, branch, version, path))
     return packages
+
+def package_install(path, packages):
+    packages = parse_package_names(packages)
+    pkgpath = path + '/.pkg'
+
+    try:
+        pkgrepo = git.Repo(pkgpath)
+    except:
+        writeln("Initializing package repository")
+        pkgrepo = git.Repo.init(pkgpath)
+    for package in packages:
+        write("Installing %s... " % package.name)
+        sys.stdout.flush()
+        try:
+            sm = pkgrepo.create_submodule(package.name, package.name,
+                                          url=package.url, branch=package.branch)
+            # FIXME: this is very slow. Do we need this versioning functionality?
+            # sm.repo.git.remote('add', 'origin', package.url)
+            # sm.repo.git.fetch('--tags')
+        except Exception as e:
+            writeln("Package install failed: " + str(e))
+        if package.version in sm.repo.tags:
+            pass
+            # FIXME: Checks out into pkgpath
+            # sm.repo.git.checkout(package.version)
+        else:
+            writeln("No such version: %s. Checking out HEAD" % package.version)
+        pkgrepo.index.commit("Installed " + package.name)
+        try:
+            installpath = os.path.abspath(pkgpath + '/' + package.name)
+            linkpath = path + '/' + package.path
+            linkbasedir = '/'.join(linkpath.split('/')[:-1])
+            try:
+                os.mkdir(linkbasedir)
+            except:
+                pass
+            os.symlink(installpath, linkpath)
+        except Exception as e:
+            writeln("Could not link package to path: " + str(e))
+        writeln("Installed.")

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -1,6 +1,6 @@
 """
 A lightweight package management system for WCosa.
-*_list functions operate on lists of data (common scenario, better efficiency).
+*_many functions operate on lists of data (common scenario, better efficiency).
 """
 import git
 import json
@@ -10,11 +10,14 @@ from wcosa.utils.output import write, writeln
 
 class Package:
     def __init__(self, name, url, branch, version, path):
-        self.name = name
+        self.unqualified_name = name
         self.url = url
         self.branch = branch
         self.version = version
         self.path = path
+        self.name = (self.unqualified_name
+            + ('-' + self.branch if self.branch != 'master' else '')
+            + ('-' + self.version if self.version != 'master' else ''))
 
     def __repr__(self):
         return ("name: %s, url: %s, branch: %s, version: %s, path: %s" %
@@ -27,6 +30,20 @@ class PackageFormatError(Exception):
     def __str__(self):
         return "Bad package format: " + self.package_string
 
+class GitFetchException(Exception):
+    def __init__(self, package):
+        self.url = (package.url +
+                    (':' + package.branch if package.branch != 'master' else '')
+                    ('@' + package.version if package.version != 'master'
+                           else ''))
+
+    def __str__(self):
+        return "Could not fetch submodule from %s" + package.url
+
+class AlreadyInstalledException(Exception):
+    def __init__(self, link_updated):
+        self.link_updated = link_updated
+
 FULL_URL = r'(?P<url>https?://\S+/(?P<name>\S+))'
 GITHUB = r'(?P<github>[\w\-]+/(?P<name>[\w\-]+))'
 BRANCH = r'(:(?P<branch>[\w\-]+))?'
@@ -35,7 +52,7 @@ PATH = r'( as (?P<path>\S+))?'
 VALID_SCHEMAS = [re.compile('^' + FULL_URL + BRANCH + VERSION + PATH + '$'),
                  re.compile('^' + GITHUB + BRANCH + VERSION + PATH + '$')]
 
-def package_string_parse_list(package_strings):
+def package_string_parse_many(package_strings):
     """
     Convert package strings to package entities.
     Package strings must match (BASE_URL|GITHUB)[:BRANCH][@VERSION][ as PATH]
@@ -66,7 +83,16 @@ def package_string_parse_list(package_strings):
         packages.append(Package(name, url, branch, version, path))
     return packages
 
-def package_info_write_list(pkgpath, packages):
+def package_list_read(pkgpath):
+    """Read package list"""
+    try:
+        with open(pkgpath + '/pkglist', 'r') as pkglistfile:
+            return json.loads(pkglistfile.read())
+    except:
+        return []
+
+def package_list_write_many(pkgpath, packages):
+    """Update package list with the given list of packages"""
     if not packages:
         return # Nothing to write
     repo = package_repo_open(pkgpath)
@@ -78,29 +104,34 @@ def package_info_write_list(pkgpath, packages):
         for package in packages:
             if package.name in pkgnames:
                 index = pkgnames.index(package.name)
-                if pkglist[index] == package.__dict__: # If same info present
+                if package.path in pkglist[index]['paths']: # Paths may not match
                     continue
-                pkglist[index] = package.__dict__
+                pkglist[index]['paths'].append(package.path)
                 updentries.append(package.name)
             else:
                 pkglist.append(package.__dict__)
+                pkglist[-1]['paths'] = [package.path]
+                del pkglist[-1]['path']
                 newentries.append(package.name)
         pkglistfile.seek(0)
         pkglistfile.write(json.dumps(pkglist))
     repo.index.add(['pkglist'])
-    repo.index.commit("Updated package list\n\n"
-                      + ("New: %s\n" % ', '.join(newentries)
-                          if newentries else "")
-                      + ("Updated: %s\n" % ', '.join(updentries)
-                          if updentries else ""))
+    if repo.is_dirty(): # Something has changed
+        repo.index.commit("Updated package list\n\n"
+                          + ("New: %s\n" % ', '.join(newentries)
+                              if newentries else "")
+                          + ("Updated: %s\n" % ', '.join(updentries)
+                              if updentries else ""))
 
 def package_repo_open(pkgpath):
+    """Try to open package repo; initalize upon failure"""
     try:
         return git.Repo(pkgpath)
     except: # If could not open, initialize
         return package_repo_init(pkgpath)
 
 def package_repo_init(pkgpath):
+    """Initialize package repo"""
     write("Initializing package repository... ")
     sys.stdout.flush()
     pkgrepo = git.Repo.init(pkgpath)
@@ -114,38 +145,101 @@ def package_repo_init(pkgpath):
 
     return pkgrepo
 
-def package_install_list(path, packages):
-    packages = package_name_parse_list(packages)
+def package_link(path, package):
+    """Link package directory from pkgpath to package.path"""
+    install_path = os.path.abspath(path + '/.pkg/' + package.name)
+    link_path = os.path.abspath(path + '/' + package.path)
+    link_basedir = '/'.join(link_path.split('/')[:-1])
+    try:
+        os.mkdir(link_basedir)
+    except:
+        pass # Already exists or failed (then next try will fail)
+    try:
+        os.symlink(install_path, link_path)
+    except Exception as e:
+        try: # Maybe the path is already linked
+            current_path = os.readlink(link_path)
+            if current_path == install_path:
+                return # Then we're done
+        except:
+            pass
+        raise (type(e))("Could not link package: " + str(e))
+
+def _package_install_unsafe(path, package, pkgrepo, pkglist, pkgnames):
+    """
+    NOT A PUBLIC INTERFACE: use package_install or package_install_many instead.
+
+    Try to install a package and forward exceptions to the caller.
+    Will leave package repository in dirty state.
+    Returns
+    """
+    write("Installing %s... " % package.name)
+    sys.stdout.flush()
+    if package.name in pkgnames:
+        index = pkgnames.index(package.name)
+        if package.path in pkglist[index]['paths']:
+            writeln("Already installed.")
+            raise AlreadyInstalledException(link_updated = False)
+        else:
+            write("Already installed, linking to %s... " % package.path)
+            sys.stdout.flush()
+            package_link(path, package)
+            writeln("Linked.")
+            raise AlreadyInstalledException(link_updated = True)
+    # If the above did not return, we need to actually install the package
+    try:
+        sm = pkgrepo.create_submodule(package.name, package.name,
+                                      url=package.url, branch=package.branch)
+    except: # Default message is cryptic
+        raise GitFetchException(package)
+    package_link(path, package)
+    writeln("Installed.")
+
+def package_install(path, package, batch_mode=False, pkgrepo=None,
+                    pkglist=None, pkgnames=None):
+    """
+    Install a package or roll back to last coherent state upon failure.
+    If batch_mode is True, do not update package list (caller will update).
+    Returns True on success, else (error or already installed) False.
+    """
     pkgpath = path + '/.pkg'
+    if pkgrepo is None:
+        pkgepo = package_repo_open(pkgpath)
+    if pkglist is None:
+        pkglist = package_list_read(pkgpath)
+    if pkgnames is None:
+        pkgnames = list(map(lambda x: x['name'], pkglist))
+    try:
+        _package_install_unsafe(path, package, pkgrepo, pkglist, pkgnames)
+        pkgrepo.index.add(['.gitmodules', package.name])
+        pkgrepo.index.commit("Installed " + package.name)
+        if not batch_mode:
+            package_list_write_many(pkgpath, [package])
+    except AlreadyInstalledException as e:
+        return e.link_updated
+    except Exception as e: # Installation failed: rollback
+        try:
+            sm = pkgrepo.submodule(package.name)
+            sm.remove()
+        except:
+            pass
+        pkgrepo.git.clean('-fdX') # Remove all untracked files
+        writeln("Install aborted.")
+        writeln(str(e))
+        return False
+    return True
+
+def package_install_many(path, packages):
+    """Install a list of packages"""
+    packages = package_string_parse_many(packages)
+    installed_packages = []
+    pkgpath = path + '/.pkg'
+    pkglist = package_list_read(pkgpath)
+    pkgnames = list(map(lambda x: x['name'], pkglist))
     pkgrepo = package_repo_open(pkgpath)
 
     for package in packages:
-        write("Installing %s... " % package.name)
-        sys.stdout.flush()
-        try:
-            sm = pkgrepo.create_submodule(package.name, package.name,
-                                          url=package.url, branch=package.branch)
-            # FIXME: this is very slow. Do we need versioning functionality?
-            # sm.repo.git.remote('add', 'origin', package.url)
-            # sm.repo.git.fetch('--tags')
-        except Exception as e:
-            writeln("Package install failed: " + str(e))
-        if package.version in sm.repo.tags:
-            pass
-            # FIXME: Checks out into pkgpath
-            # sm.repo.git.checkout(package.version)
-        else:
-            writeln("No such version: %s. Checking out HEAD" % package.version)
-        pkgrepo.index.commit("Installed " + package.name)
-        try:
-            installpath = os.path.abspath(pkgpath + '/' + package.name)
-            linkpath = path + '/' + package.path
-            linkbasedir = '/'.join(linkpath.split('/')[:-1])
-            try:
-                os.mkdir(linkbasedir)
-            except:
-                pass
-            os.symlink(installpath, linkpath)
-        except Exception as e:
-            writeln("Could not link package to path: " + str(e))
-        writeln("Installed.")
+        if package_install(path, package, True, pkgrepo, pkglist, pkgnames):
+            installed_packages.append(package) # To be written to database
+    if installed_packages:
+        package_list_write_many(pkgpath, installed_packages)

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -1,0 +1,60 @@
+import git
+import re
+from wcosa.utils.output import write, writeln
+
+class Package:
+    def __init__(self, name, url, version):
+        self.name = name
+        self.url = url
+        self.version = version
+
+    def __str__(self):
+        return "package %s version %s at %s" % (self.name, self.version, self.url)
+
+    def __repr__(self):
+        return "name: %s, version: %s, url: %s" % (self.name, self.version, self.url)
+
+class PackageFormatError(Exception):
+    def __init__(self, package_string):
+        self.package_string = package_string
+
+    def __str__(self):
+        return "Bad package format: " + self.package_string
+
+FULL_URL = r'(?P<url>https?://\S+/(?P<name>\S+))'
+GITHUB = r'(?P<github>\w+/(?P<name>\w+))'
+VERSION = r':(?P<version>\S+)'
+EXPLICIT_NAME = r'( as (?P<explicit_name>\S+))?'
+VALID_SCHEMAS = [re.compile('^' + FULL_URL + VERSION + EXPLICIT_NAME + '$'),
+                 re.compile('^' + GITHUB + VERSION + EXPLICIT_NAME + '$')]
+
+def parse_entries(package_strings):
+    """
+    Convert package strings to package entries.
+    A package string is of the form '(BASE_URL|GITHUB_SHORTHAND):VERSION [as NAME]'
+    where:
+        BASE_URL is a valid URL pointing to a git repository
+        GITHUB_SHORTHAND is of the form 'username/reponame'
+        VERSION is some tag on the given repository
+        NAME is the preferred package name
+    """
+    packages = []
+    for package_string in package_strings:
+        for schema in VALID_SCHEMAS:
+            match = re.match(schema, package_string)
+            if match:
+                groups = match.groupdict()
+                break
+        if not match:
+            raise PackageFormatError(package_string)
+        if 'github' in groups: # only a group if matched with github short form
+            url = 'https://github.com/' + groups['github']
+        else:
+            url = groups['url']
+        if groups['explicit_name']: # always a group, possibly empty
+            name = groups['explicit_name']
+        else:
+            name = groups['name']
+        version = groups['version']
+        packages.append(Package(name, url, version))
+    return packages

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -1,4 +1,9 @@
+"""
+A lightweight package management system for WCosa.
+*_list functions operate on lists of data (common scenario, better efficiency).
+"""
 import git
+import json
 import re
 import os, sys
 from wcosa.utils.output import write, writeln
@@ -25,20 +30,20 @@ class PackageFormatError(Exception):
 FULL_URL = r'(?P<url>https?://\S+/(?P<name>\S+))'
 GITHUB = r'(?P<github>[\w\-]+/(?P<name>[\w\-]+))'
 BRANCH = r'(:(?P<branch>[\w\-]+))?'
-VERSION = r'@(?P<version>\S+)'
+VERSION = r'(@(?P<version>\S+))?'
 PATH = r'( as (?P<path>\S+))?'
 VALID_SCHEMAS = [re.compile('^' + FULL_URL + BRANCH + VERSION + PATH + '$'),
                  re.compile('^' + GITHUB + BRANCH + VERSION + PATH + '$')]
 
-def parse_package_names(package_strings):
+def package_name_parse_list(package_strings):
     """
     Convert package strings to package entities.
-    A package string is of the form '(BASE_URL|GITHUB)[:BRANCH]@VERSION as PATH'
+    A package string is of the form (BASE_URL|GITHUB)[:BRANCH][@VERSION] as PATH
     where:
         FULL_URL is a valid URL pointing to a git repository
         GITHUB is of the form 'username/reponame'
         BRANCH [default master] is the branch to track
-        VERSION [default HEAD] is a tag on the given repository
+        VERSION [default HEAD] is a tag on the given branch
         PATH is the relative path to install location
     """
     packages = []
@@ -61,22 +66,66 @@ def parse_package_names(package_strings):
         packages.append(Package(name, url, branch, version, path))
     return packages
 
-def package_install(path, packages):
-    packages = parse_package_names(packages)
-    pkgpath = path + '/.pkg'
+def package_info_write_list(pkgpath, packages):
+    if not packages:
+        return # Nothing to write
+    repo = package_repo_open(pkgpath)
+    newentries = []
+    updentries = []
+    with open(pkgpath + '/pkglist', 'r+') as pkglistfile:
+        pkglist = json.loads(pkglistfile.read())
+        pkgnames = list(map(lambda x: x['name'], pkglist))
+        for package in packages:
+            if package.name in pkgnames:
+                index = pkgnames.index(package.name)
+                if pkglist[index] == package.__dict__: # If same info present
+                    continue
+                pkglist[index] = package.__dict__
+                updentries.append(package.name)
+            else:
+                pkglist.append(package.__dict__)
+                newentries.append(package.name)
+        pkglistfile.seek(0)
+        pkglistfile.write(json.dumps(pkglist))
+    repo.index.add(['pkglist'])
+    repo.index.commit("Updated package list\n\n"
+                      + ("New: %s\n" % ', '.join(newentries)
+                          if newentries else "")
+                      + ("Updated: %s\n" % ', '.join(updentries)
+                          if updentries else ""))
 
+def package_repo_open(pkgpath):
     try:
-        pkgrepo = git.Repo(pkgpath)
-    except:
-        writeln("Initializing package repository")
-        pkgrepo = git.Repo.init(pkgpath)
+        return git.Repo(pkgpath)
+    except: # If could not open, initialize
+        return package_repo_init(pkgpath)
+
+def package_repo_init(pkgpath):
+    write("Initializing package repository... ")
+    sys.stdout.flush()
+    pkgrepo = git.Repo.init(pkgpath)
+
+    with open(pkgpath + '/pkglist', 'w+') as pkglist:
+        pkglist.write('[]') # Start with empty package list
+
+    pkgrepo.index.add(['pkglist'])
+    pkgrepo.index.commit("Initialized repository")
+    writeln("Done")
+
+    return pkgrepo
+
+def package_install_list(path, packages):
+    packages = package_names_parse(packages)
+    pkgpath = path + '/.pkg'
+    pkgrepo = package_repo_open(pkgpath)
+
     for package in packages:
         write("Installing %s... " % package.name)
         sys.stdout.flush()
         try:
             sm = pkgrepo.create_submodule(package.name, package.name,
                                           url=package.url, branch=package.branch)
-            # FIXME: this is very slow. Do we need this versioning functionality?
+            # FIXME: this is very slow. Do we need versioning functionality?
             # sm.repo.git.remote('add', 'origin', package.url)
             # sm.repo.git.fetch('--tags')
         except Exception as e:

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -35,16 +35,16 @@ PATH = r'( as (?P<path>\S+))?'
 VALID_SCHEMAS = [re.compile('^' + FULL_URL + BRANCH + VERSION + PATH + '$'),
                  re.compile('^' + GITHUB + BRANCH + VERSION + PATH + '$')]
 
-def package_name_parse_list(package_strings):
+def package_string_parse_list(package_strings):
     """
     Convert package strings to package entities.
-    A package string is of the form (BASE_URL|GITHUB)[:BRANCH][@VERSION] as PATH
+    Package strings must match (BASE_URL|GITHUB)[:BRANCH][@VERSION][ as PATH]
     where:
         FULL_URL is a valid URL pointing to a git repository
         GITHUB is of the form 'username/reponame'
         BRANCH [default master] is the branch to track
-        VERSION [default HEAD] is a tag on the given branch
-        PATH is the relative path to install location
+        VERSION [default master] is a tag on the given branch
+        PATH [default 'lib/NAME'] is the relative path to install location
     """
     packages = []
     for package_string in package_strings:
@@ -61,8 +61,8 @@ def package_name_parse_list(package_strings):
             url = groups['url']
         name = groups['name']
         branch = 'master' if not groups['branch'] else groups['branch']
-        version = 'HEAD' if not groups['version'] else groups['version']
-        path = groups['path']
+        version = 'master' if not groups['version'] else groups['version']
+        path = 'lib' + name if not groups['path'] else groups['path']
         packages.append(Package(name, url, branch, version, path))
     return packages
 
@@ -115,7 +115,7 @@ def package_repo_init(pkgpath):
     return pkgrepo
 
 def package_install_list(path, packages):
-    packages = package_names_parse(packages)
+    packages = package_name_parse_list(packages)
     pkgpath = path + '/.pkg'
     pkgrepo = package_repo_open(pkgpath)
 

--- a/wcosa/command/package_manager.py
+++ b/wcosa/command/package_manager.py
@@ -2,11 +2,15 @@
 A lightweight package management system for WCosa.
 *_many functions operate on lists of data (common scenario, better efficiency).
 """
-import git
+
 import json
+import git
+import os
 import re
-import os, sys
+import sys
+
 from wcosa.utils.output import write, writeln
+
 
 class Package:
     def __init__(self, name, url, branch, version, path):
@@ -15,46 +19,53 @@ class Package:
         self.branch = branch
         self.version = version
         self.path = path
-        self.name = (self.unqualified_name
-            + ('-' + self.branch if self.branch != 'master' else '')
-            + ('-' + self.version if self.version != 'master' else ''))
+        self.name = (self.unqualified_name +
+                     ('-' + self.branch if self.branch != 'master' else '') +
+                     ('-' + self.version if self.version != 'master' else ''))
 
     def __repr__(self):
-        return ("name: %s, url: %s, branch: %s, version: %s, path: %s" %
-                    (self.name, self.url, self.branch, self.version, self.path))
+        return ('name: %s, url: %s, branch: %s, version: %s, path: %s' %
+                (self.name, self.url, self.branch, self.version, self.path))
+
 
 class PackageFormatError(Exception):
     def __init__(self, package_string):
         self.package_string = package_string
 
     def __str__(self):
-        return "Bad package format: " + self.package_string
+        return 'Bad package format: ' + self.package_string
+
 
 class GitFetchException(Exception):
     def __init__(self, package):
         self.url = (package.url +
-                    (':' + package.branch if package.branch != 'master' else '')
+                    (':' + package.branch if package.branch != 'master'
+                     else '')
                     ('@' + package.version if package.version != 'master'
-                           else ''))
+                     else ''))
 
     def __str__(self):
-        return "Could not fetch submodule from %s" + package.url
+        return 'Could not fetch submodule from %s' + package.url
+
 
 class AlreadyInstalledException(Exception):
     def __init__(self, link_updated):
         self.link_updated = link_updated
+
 
 URL = r'(?P<url>https?://\S+/(?P<name>\S+))'
 GITHUB = r'(?P<github>[\w\-]+/(?P<name>[\w\-]+))'
 BRANCH = r'(:(?P<branch>[\w\-]+))?'
 VERSION = r'(@(?P<version>\S+))?'
 PATH = r'( as (?P<path>\S+))?'
-VALID_SCHEMAS = [re.compile('^\s*' + URL + BRANCH + VERSION + PATH + '\s*$'),
-                 re.compile('^\s*' + GITHUB + BRANCH + VERSION + PATH + '\s*$')]
+VALID_SCHEMAS = [re.compile('^' + URL + BRANCH + VERSION + PATH + '$'),
+                 re.compile('^' + GITHUB + BRANCH + VERSION + PATH + '$')]
+
 
 def package_dir_path(path):
     """Return package path to package install directory"""
     return path + '/.pkg'
+
 
 def package_string_parse_many(package_strings):
     """
@@ -76,7 +87,7 @@ def package_string_parse_many(package_strings):
                 break
         if not match:
             raise PackageFormatError(package_string)
-        if 'github' in groups: # only a group if matched with github short form
+        if 'github' in groups:  # only a group if matched with github format
             url = 'https://github.com/' + groups['github']
         else:
             url = groups['url']
@@ -87,6 +98,7 @@ def package_string_parse_many(package_strings):
         packages.append(Package(name, url, branch, version, path))
     return packages
 
+
 def package_list_read(pkgpath):
     """Read package list"""
     try:
@@ -95,10 +107,11 @@ def package_list_read(pkgpath):
     except:
         return []
 
+
 def package_list_write_many(pkgpath, packages):
     """Update package list with the given list of packages"""
     if not packages:
-        return # Nothing to write
+        return  # Nothing to write
     repo = package_repo_open(pkgpath)
     newentries = []
     updentries = []
@@ -108,7 +121,7 @@ def package_list_write_many(pkgpath, packages):
         for package in packages:
             if package.name in pkgnames:
                 index = pkgnames.index(package.name)
-                if package.path in pkglist[index]['paths']: # Paths may not match
+                if package.path in pkglist[index]['paths']:
                     continue
                 pkglist[index]['paths'].append(package.path)
                 updentries.append(package.name)
@@ -120,84 +133,89 @@ def package_list_write_many(pkgpath, packages):
         pkglistfile.seek(0)
         pkglistfile.write(json.dumps(pkglist))
     repo.index.add(['pkglist'])
-    if repo.is_dirty(): # Something has changed
-        repo.index.commit("Updated package list\n\n"
-                          + ("New: %s\n" % ', '.join(newentries)
-                              if newentries else "")
-                          + ("Updated: %s\n" % ', '.join(updentries)
-                              if updentries else ""))
+    if repo.is_dirty():  # Something has changed
+        repo.index.commit('Updated package list\n\n' +
+                          ('New: %s\n' % ', '.join(newentries)
+                           if newentries else '') +
+                          ('Updated: %s\n' % ', '.join(updentries)
+                           if updentries else ''))
+
 
 def package_repo_open(pkgpath):
     """Try to open package repo; initalize upon failure"""
     try:
         return git.Repo(pkgpath)
-    except: # If could not open, initialize
+    except:
         return package_repo_init(pkgpath)
+
 
 def package_repo_init(pkgpath):
     """Initialize package repo"""
-    write("Initializing package repository... ")
+    write('Initializing package repository... ')
     sys.stdout.flush()
     pkgrepo = git.Repo.init(pkgpath)
 
     with open(pkgpath + '/pkglist', 'w+') as pkglist:
-        pkglist.write('[]') # Start with empty package list
+        pkglist.write('[]')  # Start with empty package list
 
     pkgrepo.index.add(['pkglist'])
-    pkgrepo.index.commit("Initialized repository")
-    writeln("Done")
+    pkgrepo.index.commit('Initialized repository')
+    writeln('Done')
 
     return pkgrepo
 
+
 def package_link(path, package):
     """Link package directory from pkgpath to package.path"""
-    install_path = os.path.abspath(package_dir_path(path)+ '/' + package.name)
+    install_path = os.path.abspath(package_dir_path(path) + '/' + package.name)
     link_path = os.path.abspath(path + '/' + package.path)
     link_basedir = '/'.join(link_path.split('/')[:-1])
     try:
         os.mkdir(link_basedir)
     except:
-        pass # Already exists or failed (then next try will fail)
+        pass  # Already exists or failed (then next try will fail)
     try:
         os.symlink(install_path, link_path)
     except Exception as e:
-        try: # Maybe the path is already linked
+        try:  # Maybe the path is already linked
             current_path = os.readlink(link_path)
             if current_path == install_path:
-                return # Then we're done
+                return  # Then we're done
         except:
             pass
-        raise (type(e))("Could not link package: " + str(e))
+        raise (type(e))('Could not link package: ' + str(e))
+
 
 def _package_install_unsafe(path, package, pkgrepo, pkglist, pkgnames):
     """
-    NOT A PUBLIC INTERFACE: use package_install or package_install_many instead.
+    NOT A PUBLIC INTERFACE: use package_install[_many] instead.
 
     Try to install a package and forward exceptions to the caller.
     Will leave package repository in dirty state.
     Returns
     """
-    write("Installing %s... " % package.name)
+    write('Installing %s... ' % package.name)
     sys.stdout.flush()
     if package.name in pkgnames:
         index = pkgnames.index(package.name)
         if package.path in pkglist[index]['paths']:
-            writeln("Already installed.")
-            raise AlreadyInstalledException(link_updated = False)
+            writeln('Already installed.')
+            raise AlreadyInstalledException(link_updated=False)
         else:
-            write("Already installed, linking to %s... " % package.path)
+            write('Already installed, linking to %s... ' % package.path)
             sys.stdout.flush()
             package_link(path, package)
-            writeln("Linked.")
-            raise AlreadyInstalledException(link_updated = True)
+            writeln('Linked.')
+            raise AlreadyInstalledException(link_updated=True)
     # If the above did not return, we need to actually install the package
     try:
         sm = pkgrepo.create_submodule(package.name, package.name,
                                       url=package.url, branch=package.branch)
-    except: # Default message is cryptic
+    except:  # Default message is cryptic
         raise GitFetchException(package)
     package_link(path, package)
-    writeln("Installed.")
+    writeln('Installed.')
+
 
 def package_install(path, package, batch_mode=False, pkgrepo=None,
                     pkglist=None, pkgnames=None):
@@ -216,22 +234,23 @@ def package_install(path, package, batch_mode=False, pkgrepo=None,
     try:
         _package_install_unsafe(path, package, pkgrepo, pkglist, pkgnames)
         pkgrepo.index.add(['.gitmodules', package.name])
-        pkgrepo.index.commit("Installed " + package.name)
+        pkgrepo.index.commit('Installed ' + package.name)
         if not batch_mode:
             package_list_write_many(pkgpath, [package])
     except AlreadyInstalledException as e:
         return e.link_updated
-    except Exception as e: # Installation failed: rollback
+    except Exception as e:  # Installation failed, roll back
         try:
             sm = pkgrepo.submodule(package.name)
             sm.remove()
         except:
             pass
-        pkgrepo.git.clean('-fdX') # Remove all untracked files
-        writeln("Install aborted.")
+        pkgrepo.git.clean('-fdX')  # Remove all untracked files
+        writeln('Install aborted.')
         writeln(str(e))
         return False
     return True
+
 
 def package_install_many(path, packages):
     """Install a list of packages"""
@@ -244,14 +263,15 @@ def package_install_many(path, packages):
 
     for package in packages:
         if package_install(path, package, True, pkgrepo, pkglist, pkgnames):
-            installed_packages.append(package) # To be written to database
+            installed_packages.append(package)  # To be written to database
     if installed_packages:
         package_list_write_many(pkgpath, installed_packages)
+
 
 def package_update_all(path):
     """Update all installed packages"""
     repo = package_repo_open(package_dir_path(path))
     for sm in repo.submodules:
-        write("Updating %s... " % sm.name)
+        write('Updating %s... ' % sm.name)
         sm.update()
-        writeln("Done.")
+        writeln('Done.')


### PR DESCRIPTION
## Overview
This PR adds a stand-alone file, `package_manager.py`, bringing basic package management (PM) functionality (install and update) to WCosa. CLI integration is in an upcoming PR (may be controversial).
## Rationale
This PM system aims to eliminate the need for manual git submodule bookkeeping and create a single interface through which WCosa projects can specify and manage their dependencies.
## How to test it
Currently, for the lack of a CLI, this implementation can be tested as in the following 
[session log](https://github.com/teamwaterloop/wcosa/files/1692514/session.log).