### PR TITLE
[Depends on #18] Refactored CLI argument parsing logic, added package actions

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -xe # Be verbose and exit immediately if any command fails
 
 # install wcosa
 python setup.py -q install
@@ -26,7 +27,20 @@ mkdir src/module
 cp ../test/main.cpp src/main.cpp
 cp ../test/config.json config.json
 cp ../test/module/* src/module/
-git submodule add https://github.com/teamwaterloop/wlib.git lib/wlib
+wcosa package install waterloop/wlib
 wcosa update
 wcosa build
 
+# Test Case 3
+rm -rf test-wcosa
+mkdir test-wcosa
+cd test-wcosa
+wcosa package install waterloop/wlib
+test -d .pkg/wlib && test -d lib/wlib # Exists and linked at lib/wlib
+wcosa package install waterloop/wlib at wlib-alt
+test -d wlib-alt # Now also linked at wlib-alt
+test $(readlink wlib-alt) = $(readlink lib/wlib) # Point to same location
+wcosa package remove waterloop/wlib at wlib-alt
+test -d .pkg/wlib && test ! -d wlib-alt # Still exists, but not at wlib-alt
+wcosa package remove waterloop/wlib
+test ! -d .pkg/wlib && test ! -L lib/wlib # Does not exist and no dangling link

--- a/wcosa/wcosa.py
+++ b/wcosa/wcosa.py
@@ -80,6 +80,7 @@ def parse():
         help='buad rate for serial (default: 9600)',
         type=int)
     subparsers.add_parser('boards', help='print supported boards')
+    subparsers.add_parser('clean', help='clean build files')
 
     package_parser = subparsers.add_parser(
         'package',

--- a/wcosa/wcosa.py
+++ b/wcosa/wcosa.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import argparse
 
-from wcosa.command import handle, monitor, use
+from wcosa.command import handle, monitor, package_manager, use
 from wcosa.objects.objects import Board, Fore, Generator, IDE, Path, Port
 from wcosa.parsers import board_parser
 from wcosa.utils import helper, output
@@ -16,42 +16,95 @@ def parse():
     """Adds command line arguments and returns the options"""
 
     parser = argparse.ArgumentParser(description='WCosa create, build and upload Cosa AVR projects')
-
     parser.add_argument(
-        'action',
-        help='action to perform (create, update, build, upload, serial and boards')
-    parser.add_argument(
+        '--path',
+        default=helper.get_working_directory(),
+        help='path to run action on (default: current directory)',
+        type=str)
+    subparsers = parser.add_subparsers(dest='action', metavar='action')
+    subparsers.required = True
+    create_parser = subparsers.add_parser(
+            'create',
+            help='create project')
+    create_parser.add_argument(
+        '--board',
+        help='board to use for wcosa project',
+        required=True,
+        type=str)
+    create_parser.add_argument(
+        '--ide',
+        help='create project structure for specific ide (default: none)',
+        type=str)
+    update_parser = subparsers.add_parser(
+        'update',
+        help='update project')
+    update_parser.add_argument(
         '--board',
         help='board to use for wcosa project',
         type=str)
-    parser.add_argument(
-        '--port',
-        help='port to upload the AVR traget to (default: automatic)',
-        type=str)
-    parser.add_argument(
-        '--baud',
-        help='buad rate for serial (default: 9600)',
-        type=int)
-    parser.add_argument(
+    update_parser.add_argument(
         '--ide',
-        help='create specific project structure for specific ide (default: none)',
+        help='update project structure for specific ide (default: none)',
         type=str)
-    parser.add_argument(
-        '--path',
-        help='path to create the project at (default: curr dir)',
-        type=str)
-    parser.add_argument(
+    build_parser = subparsers.add_parser(
+        'build',
+        help='build project')
+    build_parser.add_argument(
         '--generator',
         help='makefile generator to use for build (default: Unix Makefiles)',
         type=str)
-    parser.add_argument(
+    build_parser.add_argument(
         '--make',
         help='path to make binary',
         type=str)
-    parser.add_argument(
+    build_parser.add_argument(
         '--cmake',
         help='path to cmake binary',
         type=str)
+    upload_parser = subparsers.add_parser(
+        'upload',
+        help='upload project')
+    upload_parser.add_argument(
+        '--port',
+        help='port to upload the AVR traget to (default: automatic)',
+        type=str)
+    monitor_parser = subparsers.add_parser(
+        'monitor',
+        help='monitor AVR device')
+    monitor_parser.add_argument(
+        '--port',
+        help='port to monitor the AVR traget at (default: automatic)',
+        type=str)
+    monitor_parser.add_argument(
+        '--baud',
+        help='buad rate for serial (default: 9600)',
+        type=int)
+    subparsers.add_parser('boards', help='print supported boards')
+
+    package_parser = subparsers.add_parser(
+        'package',
+        help='manipulate packages')
+    package_subparsers = package_parser.add_subparsers(
+        dest='package_command',
+        metavar='command')
+    package_subparsers.required = True
+    install_parser = package_subparsers.add_parser(
+        'install',
+        help='install package(s)')
+    install_parser.add_argument(
+        'package',
+        nargs='*',
+        type=str)
+    remove_parser = package_subparsers.add_parser(
+        'remove',
+        help='remove package(s)')
+    remove_parser.add_argument(
+        'package',
+        nargs='*',
+        type=str)
+    update_parser = package_subparsers.add_parser(
+        'update',
+        help='update all packages')
 
     return parser.parse_args()
 
@@ -68,57 +121,38 @@ def print_boards():
         output.writeln('{:15s} --->\t{}'.format(curr_board, name))
 
 
-def provided(*args):
-    """checks if give flags are specified during command line usage"""
-
-    if any(flag is not None for flag in args):
-        return True
-
-
 def main():
     options = parse()
 
-    board = Board(options.board)
-    ide = IDE(options.ide)
-    port = Port(options.port)
     path = Path(options.path)
-    generator = Generator(options.generator)
-    cmake = options.cmake
-    make = options.make
 
     # based on the action call scripts
     if options.action == 'boards':
         print_boards()
     elif options.action == 'create':
-        if provided(options.port, options.generator, options.baud):
-            output.writeln('Create only requires path, board and ide, other flags are ignored', Fore.YELLOW)
-
-        if options.board is not None:
-            handle.create_wcosa(path, board, ide)
-        else:
-            output.writeln('Board is needed for creating wcosa project', Fore.RED)
+        handle.create_wcosa(path, Board(options.board), IDE(options.ide))
     elif options.action == 'update':
-        if provided(options.port, options.generator, options.baud):
-            output.writeln('Update only requires path, board and ide, other flags are ignored', Fore.YELLOW)
-
-        handle.update_wcosa(path, board, ide)
+        handle.update_wcosa(path, Board(options.board), IDE(options.ide))
     elif options.action == 'build':
-        if provided(options.port, options.ide, options.board, options.baud):
-            output.writeln('Build only requires path and generator, other flags are ignored', Fore.YELLOW)
-
-        use.build_wcosa(path, generator, make, cmake)
+        use.build_wcosa(path, Generator(options.generator),
+                        options.make, options.cmake)
     elif options.action == 'upload':
-        if provided(options.ide, options.board, options.generator, options.baud):
-            output.writeln('Upload only requires path and port, other flags are ignored', Fore.YELLOW)
-
-        use.upload_wcosa(path, port)
+        use.upload_wcosa(path, Port(options.port))
     elif options.action == 'clean':
-        if provided(options.ide, options.board, options.generator, options.port, options.baud):
-            output.writeln('Clean only requires path, other flags are ignored', Fore.YELLOW)
-
         use.clean_wcosa(path)
     elif options.action == 'monitor':
         monitor.serial_monitor(options.port, options.baud)
+    elif options.action == 'package':
+        if options.package_command == 'install':
+            package_manager.package_install_many(
+                    options.path,
+                    ' '.join(options.package).split(', '))
+        elif options.package_command == 'update':
+            package_manager.package_update_all(options.path)
+        elif options.package_command == 'remove':
+            package_manager.package_uninstall_many(
+                    options.path,
+                    ' '.join(options.package).split(', '))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Looking at the implementation of CLI actions, one can notice that parsing is currently done suboptimally:
- instead of relying on the built-in functionality provided by `argparse`, we are filtering flags manually
- invalid actions are not rejected (e.g. `wcosa asdf` falls through silently)
- there is no way to implement two-level commands (e.g. `wcosa package install`)

I propose an alternative implementation with a hierarchical structure:
- `wcosa` requires an `action`. Actions are documented under `wcosa -h`.
  - `wcosa action` takes flags depending on the type of `action`, e.g. `create` requires `--board` and optionally takes `--ide`. All actions take `--path`. Each action's flags are documented under `wcosa action -h`.
  - `wcosa package` is an action that requires a `command`, one of `install`, `update`, `remove`. This is documented under `wcosa package -h`.
    - `wcosa package install` and `wcosa package remove` take a list of `package`s, arbitrarily long.